### PR TITLE
Add get system status command

### DIFF
--- a/src/DWire.cpp
+++ b/src/DWire.cpp
@@ -528,6 +528,21 @@ uint8_t DWire::read( void )
 }
 
 /**
+ *  Reads multiple bytes from the rx buffer in little-endian order
+ */
+uint8_t * DWire::read( uint8_t byte_size )
+{
+    uint8_t[byte_size] data;
+
+    for (uint8_t i = 0; i < byte_size; ++i)
+    {
+        data[i] = read();
+    }
+
+    return data;
+}
+
+/**
  * Register the user's interrupt handler
  */
 void DWire::onRequest( void (*islHandle)( void ) ) 

--- a/src/DWire.h
+++ b/src/DWire.h
@@ -106,6 +106,7 @@ public:
     void begin( uint8_t );
 
     uint8_t read( void );
+    uint8_t * read( uint8_t );
 
     void onRequest( void (*)( void ) );
     void onReceive( void (*)( uint8_t ) );

--- a/src/EPS.cpp
+++ b/src/EPS.cpp
@@ -133,3 +133,67 @@ EPS::standard_reply EPS::cancel_operation(DWire &wire, uint8_t i2c_address) {
 
 }
 
+EPS::system_status_reply EPS::get_system_status(DWire &wire, uint8_t i2c_address) {
+    standard_reply reply;
+
+    /* Write command to EPS */
+    wire.beginTransmission(i2c_address);
+    wire.write(0x00);
+    wire.write(0x02);
+    wire.write(0x40);
+    wire.write(0x00);
+
+    // delay
+    delay_ms(25);
+
+    // request 5 bytes of data (i.e) the length of the response
+    uint8_t response = wire.requestFrom(i2c_address, 36);
+
+    // if response if 5 bytes long populate reply struct else mark error
+    if (response == 36) {
+        uint8_t* data = nullptr;
+
+        reply.stid = wire.read();
+        reply.ivid = wire.read();
+        reply.rc = wire.read();
+        reply.bid = wire.read();
+        reply.stat = wire.read();
+        reply.mode = wire.read();
+        reply.conf = wire.read();
+        reply.reset_cause = wire.read();
+
+        data = wire.read(4);
+        memcpy(&reply.uptime, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.system_error, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.rc_cnt_pwron, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.rc_cnt_wdg, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.rc_cnt_cmd, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.rc_cnt_mcu, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.rc_cnt_emlopo, data, sizeof data);
+
+        data = wire.read(2);
+        memcpy(&reply.prevcmd_elapsed, data, sizeof data);
+
+        data = wire.read(10);
+        memcpy(&reply.internal_use, data, sizeof data);
+
+        reply.error = false;
+    } else {
+        reply.error = true;
+    }
+
+    return reply;
+
+}

--- a/src/EPS.h
+++ b/src/EPS.h
@@ -46,10 +46,48 @@ public:
         uint8_t error;
     };
 
+    // system status reply
+    struct system_status_reply : standard_reply {
+        system_status_reply(
+            uint8_t stid,
+            uint8_t ivid,
+            uint8_t rc,
+            uint8_t bid,
+            uint8_t stat,
+            uint8_t mode,
+            uint8_t conf,
+            uint8_t reset_cause,
+            uint32_t uptime,
+            uint16_t system_error,
+            uint16_t rc_cnt_pwron,
+            uint16_t rc_cnt_wdg,
+            uint16_t rc_cnt_cmd,
+            uint16_t rc_cnt_mcu,
+            uint16_t rc_cnt_emlopo,
+            uint16_t prevcmd_elapsed,
+            uint8_t internal_use,
+            uint8_t error
+        ) : standard_reply(stid, ivid, rc, bid, stat, error),
+            mode(mode),
+            conf(conf),
+            reset_cause(reset_cause),
+            uptime(uptime),
+            system_error(system_error),
+            rc_cnt_pwron(rc_cnt_pwron),
+            rc_cnt_wdg(rc_cnt_wdg),
+            rc_cnt_cmd(rc_cnt_cmd),
+            rc_cnt_mcu(rc_cnt_mcu),
+            rc_cnt_emlopo(rc_cnt_emlopo),
+            prevcmd_elapsed(prevcmd_elapsed),
+            internal_use(internal_use)
+        { }
+    };
+
     static standard_reply reset_watchdog(DWire &wire, uint8_t i2c_address);
     static standard_reply no_operation(DWire &wire, uint8_t i2c_address);
     static standard_reply system_reset(DWire &wire, uint8_t i2c_address);
     static standard_reply cancel_operation(DWire &wire, uint8_t i2c_address);
+    static system_status_reply get_system_status(DWire &wire, uint8_t i2c_address);
 };
 
 #endif //EPS_CONVERSION_EPS_H


### PR DESCRIPTION
### Summary
I implemented the get system status command (pg. 47). 

### Changes
I overloaded `read` by creating another function that takes a `byte_size` parameter which tells how many bytes it should actually read. I think this method makes code way clearer.

I have also created another struct for the system status response that extends from the standard response. I don't know if this is the proper way to do it, but looking through the manual it seemed that different commands have very different response types and returning it like this made a lot of sense.

### Future Changes ?
I think that the way we have the codebase right could use some improvements. I think it would be better to have a more general `send_operation(operation, values_to_send)` function that takes an operation information and returns the specific reply. My idea was to have operations as a map (dictionary) data structures that holds for every attribute (bid, stid, ivid ...etc) a integer representing the number of bytes for that attribute and . `values_to_send` could be another map (dictionary) linking the attribute to the value that we send over the wire. This way we would have one single function to send commands. 

I think this avoids code like this: (which I think it bug-prone)
<img width="300" alt="image" src="https://github.com/davincisatellite/EPS_dev/assets/94116300/09747cd7-5ff6-4416-b364-20e956b8ff0d">



Lastly, although not as important, I think it would be better if the standard response would be a `map<string, uint_t*>`.

So `reply.bid` becomes `reply["bid"]`.

### Review

I have doubts regarding some aspects, I would appreciate it if you could take a look: (check if this is correct)
- [ ] The response types get the bytes in little-endianness order
- [ ] I created another struct for the system status response




Closes #10 